### PR TITLE
fix: 1password autostart file

### DIFF
--- a/system_files/etc/skel/.config/autostart/1password.desktop
+++ b/system_files/etc/skel/.config/autostart/1password.desktop
@@ -1,10 +1,16 @@
 [Desktop Entry]
 Name=1Password
-Exec=/usr/bin/1password --silent %U
+Exec=/opt/1Password/1password --silent %U
 Terminal=false
 Type=Application
 Icon=1password
 StartupWMClass=1Password
 Comment=Password manager and secure wallet
-MimeType=x-scheme-handler/onepassword;
+MimeType=x-scheme-handler/onepassword;x-scheme-handler/onepassword8;
 Categories=Office;
+X-GNOME-Autostart-enabled=true
+NoDisplay=false
+Hidden=false
+Name[en_US]=1Password
+Comment[en_US]=Password manager and secure wallet
+X-GNOME-Autostart-Delay=0


### PR DESCRIPTION
- correct exec path